### PR TITLE
Feature/renaming

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.dyne/freecoin-lib "0.3.0-SNAPSHOT"
+(defproject org.clojars.dyne/freecoin-lib "0.3.0"
   :description "Freecoin digital currency toolkit"
   :url "https://freecoin.dyne.org"
 

--- a/src/freecoin_lib/app.clj
+++ b/src/freecoin_lib/app.clj
@@ -1,7 +1,6 @@
 (ns freecoin-lib.app
-  (:require [clojure.pprint :refer :all]
-            [taoensso.timbre :as log]
-            [freecoin-lib.core :refer :all]
+  (:require [taoensso.timbre :as log]
+            [freecoin-lib.core :refer [new-mongo]]
             [freecoin-lib.config :as config]
             [freecoin-lib.db.mongo :as mongo]
             [freecoin-lib.db.storage :as storage]))
@@ -22,7 +21,7 @@
     (let [config     (config/create-config)
           db         (-> config config/mongo-uri mongo/get-mongo-db)
           stores     (storage/create-mongo-stores db config)
-          backend    (new-stub stores)]
+          backend    (new-mongo stores)]
       (assoc ctx
              :db db
              :config config

--- a/src/freecoin_lib/core.clj
+++ b/src/freecoin_lib/core.clj
@@ -126,7 +126,7 @@ Used to identify the class type."
               (fn [v] {"$or" [{:from-id v} {:to-id v}]})}))
 
 ;; inherits from Blockchain and implements its methods
-(defrecord Stub [stores-m]
+(defrecord Mongo [stores-m]
   Blockchain
   (label [bk] (keyword (recname bk)))
 
@@ -214,10 +214,10 @@ Used to identify the class type."
 
   (redeem-voucher [bk account-id voucher] nil))
 
-(defn new-stub
+(defn new-mongo
   "Check that the blockchain is available, then return a record"
   [stores-m]
-  (Stub. stores-m))
+  (Mongo. stores-m))
 
 (defn in-memory-filter [entry params]
   true)

--- a/src/freecoin_lib/core.clj
+++ b/src/freecoin_lib/core.clj
@@ -170,7 +170,7 @@ Used to identify the class type."
     (let [timestamp (time/format (if-let [time (:timestamp params)] time (time/now)))
           tags (or (:tags params) #{})
           transaction {:_id (str timestamp "-" from-account-id)
-                       :blockchain "STUB"
+                       :currency "MONGO"
                        :timestamp timestamp
                        :from-id from-account-id
                        :to-id to-account-id
@@ -264,7 +264,7 @@ Used to identify the class type."
     (let [now (time/format (time/add-days (time/datetime 2015 12 1) amount))
           tags (or (:tags params) #{})
           transaction {:transaction-id (str now "-" from-account-id)
-                       :blockchain "INMEMORYBLOCKCHAIN"
+                       :currency "INMEMORYBLOCKCHAIN"
                        :timestamp now
                        :from-id from-account-id
                        :to-id to-account-id

--- a/src/freecoin_lib/core.clj
+++ b/src/freecoin_lib/core.clj
@@ -50,7 +50,7 @@
   ;; transactions
   (list-transactions [bk params])
   (get-transaction   [bk account-id txid])
-  (make-transaction  [bk from-account-id amount to-account-id params from-account-email])
+  (make-transaction  [bk from-account-id amount to-account-id params])
 
   ;; tags
   (list-tags         [bk params])
@@ -166,7 +166,7 @@ Used to identify the class type."
   (get-transaction   [bk account-id txid] nil)
 
   ;; TODO: get rid of account-ids and replace with wallets
-  (make-transaction  [bk from-account-id amount to-account-id params from-account-email]
+  (make-transaction  [bk from-account-id amount to-account-id params]
     (let [timestamp (time/format (if-let [time (:timestamp params)] time (time/now)))
           tags (or (:tags params) #{})
           transaction {:_id (str timestamp "-" from-account-id)
@@ -181,7 +181,7 @@ Used to identify the class type."
       ;; amount of inserts
       (doall (map #(tag/create-tag! {:tag-store (:tag-store stores-m) 
                                      :tag %
-                                     :created-by from-account-email
+                                     :created-by from-account-id
                                      :created timestamp})
                   tags))
       ;; TODO: Keep track of accounts to verify validity of from- and
@@ -258,7 +258,7 @@ Used to identify the class type."
                                        [(second list)]))))
 
   (get-transaction   [bk account-id txid] nil)
-  (make-transaction  [bk from-account-id amount to-account-id params from-account-email]
+  (make-transaction  [bk from-account-id amount to-account-id params]
     ;; to make tests possible the timestamp here is generated starting from
     ;; the 1 december 2015 plus a number of days that equals the amount
     (let [now (time/format (time/add-days (time/datetime 2015 12 1) amount))
@@ -272,7 +272,7 @@ Used to identify the class type."
                        :amount amount}]
 
       (doall (map #(swap! tags-atom assoc {:tag %
-                                           :created-by from-account-email
+                                           :created-by from-account-id
                                            :created now})
                   tags))
       

--- a/src/freecoin_lib/db/account.clj
+++ b/src/freecoin_lib/db/account.clj
@@ -40,7 +40,8 @@
   (mongo/update! account-store email #(assoc % :activated true)))
 
 (defn fetch [account-store email]
-  (some-> (mongo/fetch account-store email)))
+  (some-> (mongo/fetch account-store email)
+          (update :flags (fn [flags] (map #(keyword %) flags)))))
 
 (defn fetch-by-activation-id [account-store activation-id]
   (first (mongo/query account-store {:activation-id activation-id})))

--- a/src/freecoin_lib/db/account.clj
+++ b/src/freecoin_lib/db/account.clj
@@ -32,6 +32,7 @@
   [account-store {:keys [first-name last-name email password] :as account-map}]
   (mongo/store! account-store :email (-> account-map
                                          (assoc :activated false)
+                                         (assoc :flags [])
                                          (update :password #(generate-hash %)))))
 
 
@@ -56,3 +57,9 @@
 
 (defn update-password! [account-store email password]
   (mongo/update! account-store email #(assoc % :password (generate-hash password))))
+
+(defn add-flag! [account-store email flag]
+  (mongo/update! account-store email (fn [account] (update account :flags #(conj % flag)))))
+
+(defn remove-flag! [account-store email flag]
+  (mongo/update! account-store email (fn [account] (update account :flags #(remove #{flag} %)))))

--- a/test/freecoin_lib/test/db/account.clj
+++ b/test/freecoin_lib/test/db/account.clj
@@ -1,0 +1,72 @@
+;; Freecoin - digital social currency toolkit
+
+;; part of Decentralized Citizen Engagement Technologies (D-CENT)
+;; R&D funded by the European Commission (FP7/CAPS 610349)
+
+;; Copyright (C) 2017 Dyne.org foundation
+
+;; Sourcecode designed, written and maintained by
+;; Aspasia Beneti <aspra@dyne.org>
+
+;; With contributions by
+;; Duncan Mortimer <dmortime@thoughtworks.com>
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU Affero General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU Affero General Public License for more details.
+
+;; You should have received a copy of the GNU Affero General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(ns freecoin-lib.test.db.account
+  (:require [midje.sweet :refer :all]
+            [freecoin-lib.db
+             [mongo :as fm]
+             [account :as account]]
+            [freecoin-lib.test.db.test-db :as test-db]
+            [taoensso.timbre :as log]))
+
+(against-background [(before :contents (test-db/setup-db))
+                     (after :contents (test-db/teardown-db))]
+
+                    
+                    (facts "Create an account"
+                           (let [account-store (fm/create-mongo-store (test-db/get-test-db) "accounts")
+                                 first-name "a-user"
+                                 last-name "user-surname"
+                                 email "user@mail.com"
+                                 pswrd "a-password"
+                                 user-account (account/new-account! account-store
+                                                                    {:first-name first-name
+                                                                     :last-name last-name
+                                                                     :email email
+                                                                     :password pswrd})]
+                             
+                             (fact "An empty flag vector is created"
+                                   (dissoc (account/fetch account-store email) :password) =>
+                                   {:first-name first-name
+                                    :last-name last-name
+                                    :email email
+                                    :flags []
+                                    :activated false}
+                                   
+                                   (:flags user-account) => [])
+
+                             (fact "Can add a flag"
+                                   (:flags (account/add-flag! account-store email :admin))  => [:admin]
+
+                                   ;; This could be a bug - have posted a question https://stackoverflow.com/questions/45677891/keyword-item-in-moger-vector-is-converted-to-string
+                                   (fact "Caution!! Mongo converts the keywords to a string"
+                                         (-> (account/fetch account-store email)
+                                             :flags
+                                             (first))  => "admin"))
+
+                             (fact "Can remove a flag"
+                                   (:flags (account/remove-flag! account-store email "admin"))  => []))))
+

--- a/test/freecoin_lib/test/db/account.clj
+++ b/test/freecoin_lib/test/db/account.clj
@@ -37,7 +37,8 @@
 
                     
                     (facts "Create an account"
-                           (let [account-store (fm/create-mongo-store (test-db/get-test-db) "accounts")
+                           (let [flag :admin
+                                 account-store (fm/create-mongo-store (test-db/get-test-db) "accounts")
                                  first-name "a-user"
                                  last-name "user-surname"
                                  email "user@mail.com"
@@ -62,10 +63,11 @@
                                    (:flags (account/add-flag! account-store email :admin))  => [:admin]
 
                                    ;; This could be a bug - have posted a question https://stackoverflow.com/questions/45677891/keyword-item-in-moger-vector-is-converted-to-string
+                                   ;; UPDATE: manually converted to a keyword
                                    (fact "Caution!! Mongo converts the keywords to a string"
                                          (-> (account/fetch account-store email)
                                              :flags
-                                             (first))  => "admin"))
+                                             (first))  => flag))
 
                              (fact "Can remove a flag"
                                    (:flags (account/remove-flag! account-store email "admin"))  => []))))

--- a/test/freecoin_lib/test/db/test_db.clj
+++ b/test/freecoin_lib/test/db/test_db.clj
@@ -1,0 +1,53 @@
+;; Freecoin - digital social currency toolkit
+
+;; part of Decentralized Citizen Engagement Technologies (D-CENT)
+;; R&D funded by the European Commission (FP7/CAPS 610349)
+
+;; Copyright (C) 2017 Dyne.org foundation
+
+;; Sourcecode designed, written and maintained by
+;; Aspasia Beneti <aspra@dyne.org>
+
+;; With contributions by
+;; Duncan Mortimer <dmortime@thoughtworks.com>
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU Affero General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU Affero General Public License for more details.
+
+;; You should have received a copy of the GNU Affero General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(ns freecoin-lib.test.db.test-db
+  (:require [monger.core :as monger]))
+
+(def test-db-name "test-db")
+(def test-db-uri (format "mongodb://localhost:27017/%s" test-db-name))
+
+(def db-and-conn (atom nil))
+
+(defn get-test-db []
+  (:db @db-and-conn))
+
+(defn get-test-db-connection []
+  (:conn @db-and-conn))
+
+(defn- drop-db [db-and-conn]
+  (monger/drop-db (:conn db-and-conn) test-db-name)
+  db-and-conn)
+
+(defn setup-db []
+  (->> (monger/connect-via-uri test-db-uri)
+       drop-db
+       (reset! db-and-conn)))
+
+(defn teardown-db []
+  (drop-db @db-and-conn)
+  (monger/disconnect (get-test-db-connection))
+  (reset! db-and-conn nil))

--- a/test/freecoin_lib/test/db/wallet.clj
+++ b/test/freecoin_lib/test/db/wallet.clj
@@ -3,10 +3,11 @@
 ;; part of Decentralized Citizen Engagement Technologies (D-CENT)
 ;; R&D funded by the European Commission (FP7/CAPS 610349)
 
-;; Copyright (C) 2015 Dyne.org foundation
+;; Copyright (C) 2017 Dyne.org foundation
 
 ;; Sourcecode designed, written and maintained by
 ;; Denis Roio <jaromil@dyne.org>
+;; Aspasia Beneti <aspra@dyne.org>
 
 ;; With contributions by
 ;; Duncan Mortimer <dmortime@thoughtworks.com>
@@ -24,7 +25,7 @@
 ;; You should have received a copy of the GNU Affero General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-(ns freecoin-lib.wallet
+(ns freecoin-lib.test.db.wallet
   (:require [midje.sweet :refer :all]
             [freecoin-lib.core :as fb]
             [freecoin-lib.db


### PR DESCRIPTION
Renamings and other changes:
- Rename the column admin to flags so an account can have a vector of keyword flags
- get rid of aacount-id when not needed
- replace the from-id and to-id with the email and get rid of from-email
- rename stub->mongo, blockchain->currency

@jaromil can you have a look? If you merge I will create a new release